### PR TITLE
Added in shape classes for rendering

### DIFF
--- a/dist/logo.svg
+++ b/dist/logo.svg
@@ -1,0 +1,1 @@
+<svg width="300" height="200" version="1.1" xmlns="http://www.w3.org/2000/svg"><rect x="90" y="40" width="150" height="150" fill="blood" /><text x="165" y="130" font-size="60" text-anchor="middle" fill="cyan">ula</text></svg>

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,35 +1,11 @@
 const inquirer = require('inquirer');
 const MaxLengthInputPrompt = require('inquirer-maxlength-input-prompt');
-const generateSVG = require('./generateSVG.js')
+const generateSVG = require('./generateSVG.js');
+const { Circle, Triangle, Square } = require('../shapes/shapes.js');
+const questions = require('./questions.js');
 const fs = require('fs');
 
-inquirer.registerPrompt('maxlength-input', MaxLengthInputPrompt)
-
-// An array of questions for the user to answer
-const questions = [
-  {
-    type: 'maxlength-input',
-    name: 'text',
-    message: 'Please enter 3 characters for your logo',
-    maxLength: 3
-  },
-  {
-    type: 'input',
-    name: 'textColor',
-    message: 'What color would you like the characters to be?',
-  },
-  {
-    type: 'list',
-    name: 'shapeSelect',
-    message: 'Pick a shape',
-    choices: ['Circle', 'Triangle', 'Square']
-  },
-  {
-    type: 'input',
-    name: 'shapeColor',
-    message: 'which color would you like for your shape?'
-  }
-]
+inquirer.registerPrompt('maxlength-input', MaxLengthInputPrompt);
 
 class CLI {
   constructor() {
@@ -54,20 +30,21 @@ class CLI {
         // Switch case that will match the users shape selection
         switch (shapeSelect) {
 
-          // Based on the users selection, it will create a new class of the desired shape and console log their selection while saving it the 'userShape' variable
+          // Based on the users selection, it will create and render a new class of the desired shape and console log their selection while saving it the 'userShape' variable
            case "Circle":
             console.log(log);
-            userShape = `<circle cx="150" cy="100" r="95" height="100%" width="100%" fill="${shapeColor}" /><text x="150" y="115" font-size="60" text-anchor="middle" fill="${textColor}">${text}</text>`;
+            userShape = new Circle(text, textColor, shapeColor).render();
+            console.log(userShape);
             break;
 
            case "Triangle":
             console.log(log);
-            userShape = `<polygon height="100%" width="100%" points="20,200 275,200 150,10" fill="${shapeColor}" /><text x="150" y="160" font-size="60" text-anchor="middle" fill="${textColor}">${text}</text>`
+            userShape = new Triangle(text, textColor, shapeColor).render();
             break;
 
            case "Square":
             console.log(log);
-            userShape = `<rect x="90" y="40" width="150" height="150" fill="${shapeColor}" /><text x="165" y="130" font-size="60" text-anchor="middle" fill="${textColor}">${text}</text>`
+            userShape = new Square(text, textColor, shapeColor).render();
             break;
         }
 

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -1,0 +1,27 @@
+// An array of questions for the user to answer
+const questions = [
+    {
+      type: 'maxlength-input',
+      name: 'text',
+      message: 'Please enter 3 characters for your logo',
+      maxLength: 3
+    },
+    {
+      type: 'input',
+      name: 'textColor',
+      message: 'What color would you like the characters to be?',
+    },
+    {
+      type: 'list',
+      name: 'shapeSelect',
+      message: 'Pick a shape',
+      choices: ['Circle', 'Triangle', 'Square']
+    },
+    {
+      type: 'input',
+      name: 'shapeColor',
+      message: 'which color would you like for your shape?'
+    }
+];
+
+module.exports = questions;

--- a/shapes/shapes.js
+++ b/shapes/shapes.js
@@ -1,0 +1,28 @@
+// Class Shapes that takes in the users data and passes it into the subclass based on the users shape collection
+class Shapes {
+  constructor(text, colorText, colorShape) {
+    this.text = text,
+    this.colorText = colorText,
+    this.colorShape = colorShape
+  }
+}
+
+class Circle extends Shapes {
+  render() {
+    return `<circle cx="150" cy="100" r="95" height="100%" width="100%" fill="${this.colorShape}" /><text x="150" y="115" font-size="60" text-anchor="middle" fill="${this.colorText}">${this.text}</text>`
+  }
+}
+  
+class Triangle extends Shapes {
+  render() {
+    return `<polygon height="100%" width="100%" points="20,200 275,200 150,10" fill="${this.colorShape}" /><text x="150" y="160" font-size="60" text-anchor="middle" fill="${this.colorText}">${this.text}</text>`
+  }
+}
+  
+class Square extends Shapes {
+  render() {
+    return `<rect x="90" y="40" width="150" height="150" fill="${this.colorShape}" /><text x="165" y="130" font-size="60" text-anchor="middle" fill="${this.colorText}">${this.text}</text>`
+  }
+}
+
+module.exports = { Circle, Triangle, Square };


### PR DESCRIPTION
The following adjustments that were made on this branch were to ensure I was able to utilize Classes with my Switch Case statement to generate a users shape through Object-Oriented Programming.

To start I took the `questions` array and created the `questions.js` file to store it in to help clean the look of `cli.js`, I am still able to utilize the `questions` array through it's file w/ inquirer (Line 5).

I tried to implement `shapes.js` in earlier pushes but found it stressful and tried to simplify the results which worked but did not properly demonstrated OOP, I moved the SVG data from each `userShape` and created subclasses to represent each shape (Circle, Triangle, and Square) which extends from the `Shape` class within `shapes.js`.

Now when a user selects a shape, the switch case will still behave the same but the stored contents within `userShape` will create a new class (of the user selected shape) and return the SVG data that is now rendered with the users passed in data (text, colorText and colorShape).

Everything still works the same on the surface of the application but now demonstrates OOP within the repository.